### PR TITLE
Correct typos and improve wording

### DIFF
--- a/pkg-provides.8
+++ b/pkg-provides.8
@@ -17,8 +17,8 @@
 .Dt PKG-PROVIDES 8
 .Os
 .Sh NAME
-.Nm pkg provides
-query which package provides a file with a particular pattern
+.Nm "pkg provides"
+.Nd query which package provides a file matching a particular pattern
 .Sh SYNOPSIS
 .Nm
 .Op Fl u
@@ -28,7 +28,7 @@ query which package provides a file with a particular pattern
 .Sh DESCRIPTION
 .Nm
 is used to query which package in your pkg catalog provides a particular
-file given pattern.
+file given a pattern.
 .Pp
 The search pattern can be any perl compatible regular expression (PCRE).
 .Sh OPTIONS
@@ -36,9 +36,9 @@ The following options are supported by
 .Nm :
 .Bl -tag -width repository
 .It Fl u
-Check if a new database file is available and then performs the update.
+Check if a new database file is available and then perform the update.
 .It Fl f
-Forces the update.
+Force the update.
 .It Sy pattern
 Can be any perl compatible regular expression (PCRE). The search is not case sensitive.
 .Sh EXIT STATUS
@@ -46,7 +46,7 @@ Can be any perl compatible regular expression (PCRE). The search is not case sen
 .Sh ENVIRONMENT
 .Bl -tag -width "PROVIDES_FETCH_ON_UPDATE"
 .It PROVIDES_FETCH_ON_UPDATE
-If set to "NO", it disables the default behaviour and don't perform a
+If set to "NO", it disables the default behaviour and doesn't perform a
 .Nm
 database update after updating pkg.
 .Sh EXAMPLES
@@ -54,11 +54,11 @@ Update the provides database:
 .Pp
 .Dl $ pkg provides -u
 .Pp
-Search which package provides bin/firefox
+Search for a package that provides bin/firefox
 .Pp
 .Dl $ pkg provides bin/firefox$
 .Pp
-Search which packages provides a file with the pattern libbz2.so.*
+Search for packages that provide a file with the pattern libbz2.so.*
 .Pp
 .Dl $ pkg provides ^libbz2.so.
 .Pp

--- a/provides.c
+++ b/provides.c
@@ -227,7 +227,7 @@ plugin_fetch_file(void)
             return -1;
         }
         if(us.mtime < sb.st_mtim.tv_sec && (!force_flag)) {
-            printf("The provides database is up to date.\n");
+            printf("The provides database is up-to-date.\n");
             return (0);
         }
     }
@@ -243,7 +243,7 @@ plugin_fetch_file(void)
         goto error;
     }
 
-    provides_progressbar_start("Feching provides database");
+    provides_progressbar_start("Fetching provides database");
     provides_progressbar_tick(size,us.size);
     while ((count = fread(buffer, 1, BUFLEN, fi)) > 0) {
         if(write(fo, buffer, count) != count) {
@@ -382,21 +382,21 @@ plugin_provides_search(char *pattern)
 
     fh = fopen(PKG_DB_PATH "provides.db","rb");
     if (fh == NULL) {
-        fprintf(stderr, "Provides database not found, please update before.\n");
+        fprintf(stderr, "Provides database not found, please update first.\n");
         return (-1);
     }
 
     pcre = pcre_compile(pattern, 0, &pcreErrorStr, &pcreErrorOffset, NULL);
 
     if(pcre == NULL) {
-        fprintf(stderr, "Invalid serach pattern\n");
+        fprintf(stderr, "Invalid search pattern\n");
         goto error_pcre;
     }
 
     pcreExtra = pcre_study(pcre, 0, &pcreErrorStr);
 
     if(pcreExtra == NULL) {
-        fprintf(stderr, "Invalid serach pattern\n");
+        fprintf(stderr, "Invalid search pattern\n");
         goto error_pcre;
     }
 


### PR DESCRIPTION
I noticed pkg provides output including the typo "Feching" for "Fetching" so have corrected this and a couple of other typos. I've also improved other aspects of the wording in the man page.

Much of this is consistency of verb forms: It had, e.g. "check" and "performs" in the same sentence. My patch takes the first form which I find cleaner. The second verb form would be fine, the meaning is only subtly different, but mixing the two forms is not.

Use of "first" instead of "before". If you use "before" then the sentence should indicate _what_ it should be before.

"Search which" is not a correct form. You either search _for_ something or the direct object after search is where you're searching, e.g Search the repository for a package.