### PR TITLE
Allow the full URL to the database to be overridden.

### DIFF
--- a/configure.c
+++ b/configure.c
@@ -57,3 +57,9 @@ config_get_remote_url()
     }
     return (url);
 }
+
+char *
+config_get_full_remote_url()
+{
+    return getenv("PROVIDES_FULL_URL");
+}

--- a/pkg-provides.8
+++ b/pkg-provides.8
@@ -56,6 +56,8 @@ When set, overrides the default
 .Nm
 server URL.
 The default value is "https://pkg-provides.osorio.me".
+.It PROVIDES_FULL_URL
+When set, overrides the full URL to the package database. The default value depends on $PROVIDES_URL and the operating system version. This takes precedence over PROVIDES_URL.
 .El
 .Sh EXIT STATUS
 .Ex -std


### PR DESCRIPTION
I wanted to use the tool on a DragonflyBSD system that's following master. By default `pkg provides -u` searches for `https://pkg-provides.osorio.me/v3/DragonFly/6.1:x86:64/provides.db.xz` which doesn't exist yet. With this change, I can add `PROVIDES_FULL_URL=https://pkgprovides.osorio.me/v3/DragonFly/6.0:x86:64/provides.db.xz` to my environment when running `pkg provides -u`, and get the database for the 6.0 release. It might not quite match my current system, but it's better than no DB!